### PR TITLE
docs(storybook): use new addon-designs plugin

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -5,7 +5,7 @@ export default {
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',
-    'storybook-addon-designs',
+    '@storybook/addon-designs',
     '@storybook/addon-storysource',
     {
       name: '@storybook/addon-docs',

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@rollup/plugin-typescript": "^11.0.0",
         "@storybook/addon-actions": "7.1.0",
+        "@storybook/addon-designs": "^7.0.1",
         "@storybook/addon-docs": "7.1.0",
         "@storybook/addon-essentials": "7.1.0",
         "@storybook/addon-links": "7.1.0",
@@ -76,7 +77,6 @@
         "sass": "^1.57.1",
         "sass-loader": "^13.2.0",
         "storybook": "^7.1.0",
-        "storybook-addon-designs": "^7.0.0-beta.2",
         "storybook-preset-inline-svg": "^1.0.1",
         "svg-inline-loader": "^0.8.2",
         "typescript": "^4.9.4"
@@ -4240,6 +4240,33 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/addon-designs": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-designs/-/addon-designs-7.0.1.tgz",
+      "integrity": "sha512-bp7eoOYnoKp48H7tx0nkhhi9y7qUBr2YE9pd2DdxlS+4s2REglVeh1bNbBEYg9QUKPeKgUoWLMonLMTuCUyLoQ==",
+      "dev": true,
+      "dependencies": {
+        "@figspec/react": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@storybook/addon-docs": "^7.0.0",
+        "@storybook/addons": "^7.0.0",
+        "@storybook/components": "^7.0.0",
+        "@storybook/manager-api": "^7.0.0",
+        "@storybook/preview-api": "^7.0.0",
+        "@storybook/theming": "^7.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       },
@@ -23869,32 +23896,6 @@
         "url": "https://opencollective.com/storybook"
       }
     },
-    "node_modules/storybook-addon-designs": {
-      "version": "7.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/storybook-addon-designs/-/storybook-addon-designs-7.0.0-beta.2.tgz",
-      "integrity": "sha512-ljBNmyCJdPTXhiBSfA1S+GBxtMooW2M7nxlt49OoCRH7jcxZOYQdiI8JYQiMF5Ur0MGakbSci0Xm+JzAvcm02g==",
-      "dev": true,
-      "dependencies": {
-        "@figspec/react": "^1.0.0"
-      },
-      "peerDependencies": {
-        "@storybook/addon-docs": "^6.4.0 || ^7.0.0",
-        "@storybook/addons": "^6.4.0 || ^7.0.0",
-        "@storybook/api": "^6.4.0 || ^7.0.0",
-        "@storybook/components": "^6.4.0 || ^7.0.0",
-        "@storybook/theming": "^6.4.0 || ^7.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/storybook-preset-inline-svg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/storybook-preset-inline-svg/-/storybook-preset-inline-svg-1.0.1.tgz",
@@ -29026,6 +29027,15 @@
         "@storybook/types": "7.1.0",
         "lodash": "^4.17.21",
         "ts-dedent": "^2.0.0"
+      }
+    },
+    "@storybook/addon-designs": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-designs/-/addon-designs-7.0.1.tgz",
+      "integrity": "sha512-bp7eoOYnoKp48H7tx0nkhhi9y7qUBr2YE9pd2DdxlS+4s2REglVeh1bNbBEYg9QUKPeKgUoWLMonLMTuCUyLoQ==",
+      "dev": true,
+      "requires": {
+        "@figspec/react": "^1.0.0"
       }
     },
     "@storybook/addon-docs": {
@@ -43696,15 +43706,6 @@
       "dev": true,
       "requires": {
         "@storybook/cli": "7.1.0"
-      }
-    },
-    "storybook-addon-designs": {
-      "version": "7.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/storybook-addon-designs/-/storybook-addon-designs-7.0.0-beta.2.tgz",
-      "integrity": "sha512-ljBNmyCJdPTXhiBSfA1S+GBxtMooW2M7nxlt49OoCRH7jcxZOYQdiI8JYQiMF5Ur0MGakbSci0Xm+JzAvcm02g==",
-      "dev": true,
-      "requires": {
-        "@figspec/react": "^1.0.0"
       }
     },
     "storybook-preset-inline-svg": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^11.0.0",
     "@storybook/addon-actions": "7.1.0",
+    "@storybook/addon-designs": "^7.0.1",
     "@storybook/addon-docs": "7.1.0",
     "@storybook/addon-essentials": "7.1.0",
     "@storybook/addon-links": "7.1.0",
@@ -95,7 +96,6 @@
     "sass": "^1.57.1",
     "sass-loader": "^13.2.0",
     "storybook": "^7.1.0",
-    "storybook-addon-designs": "^7.0.0-beta.2",
     "storybook-preset-inline-svg": "^1.0.1",
     "svg-inline-loader": "^0.8.2",
     "typescript": "^4.9.4"

--- a/src/components/button/Button.stories.js
+++ b/src/components/button/Button.stories.js
@@ -1,4 +1,3 @@
-import { withDesign } from 'storybook-addon-designs';
 import { html } from 'lit';
 import './button';
 import '../icon';
@@ -7,7 +6,6 @@ import arrowRightIcon from '@carbon/icons/es/arrow--right/16';
 export default {
   title: 'Components/Button (WIP)',
   component: 'kyn-button',
-  decorators: [withDesign],
   argTypes: {
     kind: {
       control: { type: 'select' },

--- a/src/components/icon/icon.ts
+++ b/src/components/icon/icon.ts
@@ -14,7 +14,7 @@ export class Icon extends LitElement {
 
   /** The imported Carbon icon. */
   @property({ type: Object })
-  icon: Object = {};
+  icon: any = {};
 
   /** Icon fill color. */
   @property({ type: String })

--- a/src/components/icon/icon.ts
+++ b/src/components/icon/icon.ts
@@ -14,7 +14,7 @@ export class Icon extends LitElement {
 
   /** The imported Carbon icon. */
   @property({ type: Object })
-  icon: any = {};
+  icon: Object = {};
 
   /** Icon fill color. */
   @property({ type: String })


### PR DESCRIPTION
## Summary

Replaced `storybook-addon-designs` with the new official `@storybook/addon-designs` plugin for embedding Figma designs.
